### PR TITLE
feat: add support for custom TLS configurations

### DIFF
--- a/core/service/fhttp/README.md
+++ b/core/service/fhttp/README.md
@@ -159,7 +159,6 @@ tRPC-Gateway handles the following to accommodate both client-facing and trpc cl
 The tRPC-Gateway provides users a way to register custom TLS configurations for incoming HTTPS requests. For example, when the tRPC-Gateway enables the mutual TLS for incoming requests，client certificate can be verified in the following way:
 
 First, configure the mutual TLS in trpc_go.yaml by filling in the tls_key, tls_cert, and ca_cert in server.service section.
-
 ```yaml
 server: #server configuration
   app: inews                                    #Business application name
@@ -181,7 +180,6 @@ server: #server configuration
       tls_cert: ./server.crt    # server's certificate
       ca_cert: ./ca.pem         # client's CA certificate
 ``` 
- 
 
 Then, in main.go, register a custom client certificate validation function.
 ```go
@@ -207,7 +205,7 @@ func main() {
 
 Using fhttp.RegisterTLSConfig, one or more TLS configurations can be registered at once. Currently, only fhttp.WithTLSPeerVerifier is provided, and more can be added as needed in the future.
 ```go
-// RegisterTLSConfig 注册一个或多个 TLSOption 到网关中
+// RegisterTLSConfig registers one or more TLSOption into the gateway.
 func RegisterTLSConfig(opts ...TLSOption) {
 	customTLSOptions = append(customTLSOptions, opts...)
 }

--- a/core/service/fhttp/tls.go
+++ b/core/service/fhttp/tls.go
@@ -1,0 +1,32 @@
+package fhttp
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+)
+
+// TLSOption is a function type used to set one attribute of *tls.Config.
+type TLSOption func(o *tls.Config)
+
+var (
+	customTLSOptions = make([]TLSOption, 0)
+)
+
+// RegisterTLSConfig registers one or more TLSOption into the gateway.
+func RegisterTLSConfig(opts ...TLSOption) {
+	customTLSOptions = append(customTLSOptions, opts...)
+}
+
+// SetCustomTLSOptions applies all registered TLSOption to *tls.Config.
+func SetCustomTLSOptions(tlsConfig *tls.Config) {
+	for _, o := range customTLSOptions {
+		o(tlsConfig)
+	}
+}
+
+// WithTLSPeerVerifier creates a TLSOption used to set the VerifyPeerCertificate attribute in *tls.Config.
+func WithTLSPeerVerifier(f func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error) TLSOption {
+	return func(o *tls.Config) {
+		o.VerifyPeerCertificate = f
+	}
+}

--- a/core/service/fhttp/tls_test.go
+++ b/core/service/fhttp/tls_test.go
@@ -1,0 +1,31 @@
+package fhttp
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterTlsConfig(t *testing.T) {
+	RegisterTLSConfig(WithTLSPeerVerifier(func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		t.Log("this is a test for tls peer verifier who return nil")
+		return nil
+	}))
+	tlsConfig := &tls.Config{}
+	SetCustomTLSOptions(tlsConfig)
+	assert.Nil(t, tlsConfig.VerifyPeerCertificate(nil, nil))
+	t.Log("TlsPeerVerifier test pass for nil return")
+
+	errStr := "this is a test for tls peer verifier"
+	RegisterTLSConfig(WithTLSPeerVerifier(func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		t.Log("this is a test for tls peer verifier who return an error")
+		return errors.New(errStr)
+	}))
+	SetCustomTLSOptions(tlsConfig)
+	assert.NotNil(t, tlsConfig.VerifyPeerCertificate(nil, nil))
+	assert.Equal(t, tlsConfig.VerifyPeerCertificate(nil, nil).Error(), errStr)
+	t.Log("TlsPeerVerifier test pass for error return")
+}

--- a/core/service/fhttp/tls_test.go
+++ b/core/service/fhttp/tls_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRegisterTlsConfig(t *testing.T) {
 	RegisterTLSConfig(WithTLSPeerVerifier(func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		t.Log("this is a test for tls peer verifier who return nil")
+		t.Log("this is a test for tls peer verifier who returns nil")
 		return nil
 	}))
 	tlsConfig := &tls.Config{}
@@ -21,7 +21,7 @@ func TestRegisterTlsConfig(t *testing.T) {
 
 	errStr := "this is a test for tls peer verifier"
 	RegisterTLSConfig(WithTLSPeerVerifier(func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		t.Log("this is a test for tls peer verifier who return an error")
+		t.Log("this is a test for tls peer verifier who returns an error")
 		return errors.New(errStr)
 	}))
 	SetCustomTLSOptions(tlsConfig)

--- a/core/service/fhttp/transport.go
+++ b/core/service/fhttp/transport.go
@@ -231,6 +231,7 @@ func generateTLSConfig(opts *transport.ListenServeOptions) (*tls.Config, error) 
 			tlsConf.ClientCAs = pool
 		}
 	}
+	SetCustomTLSOptions(tlsConf)
 	return tlsConf, nil
 }
 


### PR DESCRIPTION
Supports custom TLS configurations

Background:

- Currently, the gateway uses the crypto/tls standard library to implement TLS communication. The crypto/tls library itself supports many custom configurations for TLS. However, the gateway currently does not expose these configuration capabilities, resulting in some customized configurations not being achievable, such as custom validation of TLS certificates, which requires setting the tls.Config.VerifyPeerCertificate function.

Modifications:

- Add the capability to customize TLS configurations, registering user-defined TLS configurations into the gateway.
- Expose the tls.Config.VerifyPeerCertificate function through WithTlsPeerVerifier(), allowing users to customize the certificate verification method.